### PR TITLE
Make log messages work when output overloads missing for time types.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,8 @@
 *.app
 
 test
+/main
+/main-debug
+/.idea/
 
 .ccls-cache


### PR DESCRIPTION
I changed things so you shouldn't get the compile errors you were getting.